### PR TITLE
CLIENT-5628 | Fix client stop ringing when making a call repeatedly

### DIFF
--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -224,6 +224,9 @@ export default class AudioPlayer extends EventTarget {
     this._audioNode.start();
 
     if (this._audioElement.srcObject) {
+      this.addEventListener('ended', () => {
+        this._audioElement.srcObject = null;
+      });
       return this._audioElement.play();
     }
   }
@@ -250,7 +253,6 @@ export default class AudioPlayer extends EventTarget {
       this._destination = this._audioContext.destination;
       this._gainNode.connect(this._destination);
       this._sinkId = sinkId;
-
       return;
     }
 

--- a/test/AudioPlayer.ts
+++ b/test/AudioPlayer.ts
@@ -165,6 +165,16 @@ describe('AudioPlayer', function() {
         });
       });
 
+      it('should clear srcObject if a sinkId is set', () => {
+        audioPlayer.setSinkId('foo');
+
+        return audioPlayer.play().then(() => {
+          audioContext.audioNodes[0].dispatchEvent('ended');
+          assert.equal(AudioFactory.instances.length, 1);
+          assert.equal(AudioFactory.instances[0].srcObject, null);
+        });
+      });
+
       context('when already playing', () => {
         it('should not create another audio node', () => {
           audioPlayer.play();
@@ -518,6 +528,8 @@ class LegacyAudioFactory {
   static clear() {
     this.instances.splice(0, this.instances.length);
   }
+
+  srcObject: any;
 
   constructor() {
     this.play = sinon.spy(this.play);


### PR DESCRIPTION
Audio objects for streams are not properly released which causes client to stop ringing when making a call repeatedly. This PR will address the issue