### PR TITLE
Don't automatically destroy object. Allow the consumer to do it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio/audioplayer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "An HTMLAudioElement-like implementation that uses AudioContext to circumvent browser limitations.",
   "main": "./es5/index.js",
   "repository": {

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -4,12 +4,6 @@ import EventTarget from './EventTarget';
 import ChromeAudioContext, { ChromeHTMLAudioElement, MediaStreamAudioDestinationNode } from './ChromeAudioContext';
 
 /**
- * HTMLMediaElement srcObject
- * @private
- */
-export type ISourceObject = any;
-
-/**
  * Options that may be passed to AudioPlayer for dependency injection.
  */
 export interface IAudioPlayerOptions {
@@ -128,10 +122,10 @@ export default class AudioPlayer extends EventTarget {
   /**
    * The srcObject of the HTMLMediaElement
    */
-  get srcObject(): ISourceObject {
+  get srcObject(): MediaStream | MediaSource | Blob | undefined {
     return this._audioElement.srcObject;
   }
-  set srcObject(srcObject: ISourceObject) {
+  set srcObject(srcObject: MediaStream | MediaSource | Blob | undefined) {
     this._audioElement.srcObject = srcObject;
   }
 

--- a/src/AudioPlayer.ts
+++ b/src/AudioPlayer.ts
@@ -4,6 +4,12 @@ import EventTarget from './EventTarget';
 import ChromeAudioContext, { ChromeHTMLAudioElement, MediaStreamAudioDestinationNode } from './ChromeAudioContext';
 
 /**
+ * HTMLMediaElement srcObject
+ * @private
+ */
+export type ISourceObject = any;
+
+/**
  * Options that may be passed to AudioPlayer for dependency injection.
  */
 export interface IAudioPlayerOptions {
@@ -120,6 +126,16 @@ export default class AudioPlayer extends EventTarget {
   }
 
   /**
+   * The srcObject of the HTMLMediaElement
+   */
+  get srcObject(): ISourceObject {
+    return this._audioElement.srcObject;
+  }
+  set srcObject(srcObject: ISourceObject) {
+    this._audioElement.srcObject = srcObject;
+  }
+
+  /**
    * The current sinkId of the device audio is being played through.
    */
   private _sinkId: string = 'default';
@@ -224,9 +240,6 @@ export default class AudioPlayer extends EventTarget {
     this._audioNode.start();
 
     if (this._audioElement.srcObject) {
-      this.addEventListener('ended', () => {
-        this._audioElement.srcObject = null;
-      });
       return this._audioElement.play();
     }
   }

--- a/test/AudioPlayer.ts
+++ b/test/AudioPlayer.ts
@@ -165,16 +165,6 @@ describe('AudioPlayer', function() {
         });
       });
 
-      it('should clear srcObject if a sinkId is set', () => {
-        audioPlayer.setSinkId('foo');
-
-        return audioPlayer.play().then(() => {
-          audioContext.audioNodes[0].dispatchEvent('ended');
-          assert.equal(AudioFactory.instances.length, 1);
-          assert.equal(AudioFactory.instances[0].srcObject, null);
-        });
-      });
-
       context('when already playing', () => {
         it('should not create another audio node', () => {
           audioPlayer.play();


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

This PR allows reusing the AudioPlayer.
Before, we always destroy the srcObject on 'ended'. Now, the consumer can decide when to destroy it.
